### PR TITLE
consola 로그 도입

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,10 +1,10 @@
-import eslint from "@eslint/js";
-import tseslint from "typescript-eslint";
-import eslintConfigPrettier from "eslint-config-prettier";
-import jsdoc from "eslint-plugin-jsdoc";
-import globals from "globals";
-import mochaPlugin from "eslint-plugin-mocha";
-import licenseHeader from 'eslint-plugin-license-header';
+import eslint from "@eslint/js"
+import tseslint from "typescript-eslint"
+import eslintConfigPrettier from "eslint-config-prettier"
+import jsdoc from "eslint-plugin-jsdoc"
+import globals from "globals"
+import mochaPlugin from "eslint-plugin-mocha"
+import licenseHeader from "eslint-plugin-license-header"
 
 export default tseslint.config(
     {
@@ -44,7 +44,7 @@ export default tseslint.config(
         },
         plugins: {
             jsdoc,
-            "license-header": licenseHeader
+            "license-header": licenseHeader,
         },
         rules: {
             // TypeScript 관련 규칙
@@ -131,4 +131,4 @@ export default tseslint.config(
     },
     // Prettier와의 충돌 방지
     eslintConfigPrettier,
-);
+)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -87,25 +87,28 @@ export default tseslint.config(
 
             // 라이센스 헤더 규칙
             "license-header/header": [
-              "error",
-              [
-                "/*",
-                " * Copyright " + new Date().getFullYear() + " the original author or authors.",
-                " *",
-                " * Licensed under the Apache License, Version 2.0 (the \"License\");",
-                " * you may not use this file except in compliance with the License.",
-                " * You may obtain a copy of the License at",
-                " *",
-                " *    http://www.apache.org/licenses/LICENSE-2.0",
-                " *",
-                " * Unless required by applicable law or agreed to in writing, software",
-                " * distributed under the License is distributed on an \"AS IS\" BASIS,",
-                " * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
-                " * See the License for the specific language governing permissions and",
-                " * limitations under the License.",
-                " */"
-              ]
-            ]
+                "error",
+                [
+                    "/*",
+                    " * Copyright " + new Date().getFullYear() + " the original author or authors.",
+                    " *",
+                    ' * Licensed under the Apache License, Version 2.0 (the "License");',
+                    " * you may not use this file except in compliance with the License.",
+                    " * You may obtain a copy of the License at",
+                    " *",
+                    " *    http://www.apache.org/licenses/LICENSE-2.0",
+                    " *",
+                    " * Unless required by applicable law or agreed to in writing, software",
+                    ' * distributed under the License is distributed on an "AS IS" BASIS,',
+                    " * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+                    " * See the License for the specific language governing permissions and",
+                    " * limitations under the License.",
+                    " */",
+                ],
+            ],
+
+            // no-console 규칙
+            "no-console": "error",
         },
         // JSDoc 설정
         settings: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,9 @@ import mochaPlugin from "eslint-plugin-mocha";
 import licenseHeader from 'eslint-plugin-license-header';
 
 export default tseslint.config(
+    {
+        ignores: ["**/node_modules/**", "**/build/**", "**/examples/**", "tsup.config.ts"],
+    },
     // ESLint 기본 추천 규칙
     eslint.configs.recommended,
     // TypeScript 추천 규칙
@@ -20,16 +23,7 @@ export default tseslint.config(
         },
     },
     {
-        // TypeScript 파일만 대상으로 함
         files: ["**/*.ts"],
-        ignores: [
-            "**/node_modules/**",
-            "**/build/**",
-            "**/dist/**",
-            "**/*.js",
-            "**/*.cjs",
-            "**/*.mjs",
-        ],
         languageOptions: {
             // 사용할 JavaScript 버전 지정
             ecmaVersion: 2022,

--- a/examples/express/__tests__/expressApp.test.js
+++ b/examples/express/__tests__/expressApp.test.js
@@ -16,6 +16,7 @@ describeAPI(
         itDoc("회원가입 성공", () => {
             return apiDoc
                 .test()
+                .prettyPrint()
                 .req()
                 .body({
                     username: "penekhun",

--- a/lib/__tests__/unit/config/logger.test.ts
+++ b/lib/__tests__/unit/config/logger.test.ts
@@ -19,7 +19,7 @@ import * as sinon from "sinon"
 import chalk from "chalk"
 import logger from "../../../config/logger"
 
-describe("logger 는", () => {
+describe("logger", () => {
     let consoleStub: sinon.SinonStub
 
     beforeEach(() => {
@@ -30,32 +30,34 @@ describe("logger 는", () => {
         consoleStub.restore()
     })
 
-    it("INFO 테스트", () => {
-        logger.info(
-            "회원 가입 성공",
-            {
-                username: "penekhun",
-                name: "MoonSeonghun",
-            },
-            "가입 시기 : 2025-01-01",
-        )
+    context("info 호출시", () => {
+        it("로그가 잘 출력된다.", () => {
+            logger.info(
+                "회원 가입 성공",
+                {
+                    username: "penekhun",
+                    name: "MoonSeonghun",
+                },
+                "가입 시기 : 2025-01-01",
+            )
 
-        const [labelLine, ...extraLines] = consoleStub.getCalls().map((c) => c.args[0])
+            const [labelLine, ...extraLines] = consoleStub.getCalls().map((c) => c.args[0])
 
-        expect(labelLine).to.equal(
-            chalk.bgBlue(chalk.white.bold("[INFO]")) + "  " + chalk.blue("회원 가입 성공"),
-        )
+            expect(labelLine).to.equal(
+                chalk.bgBlue(chalk.white.bold("[INFO]")) + "  " + chalk.blue("회원 가입 성공"),
+            )
 
-        expect(extraLines).to.deep.equal([
-            "       ↳ {\n" +
-                '         "username": "penekhun",\n' +
-                '         "name": "MoonSeonghun"\n' +
-                "       }",
-            "       ↳ 가입 시기 : 2025-01-01",
-        ])
+            expect(extraLines).to.deep.equal([
+                "       ↳ {\n" +
+                    '         "username": "penekhun",\n' +
+                    '         "name": "MoonSeonghun"\n' +
+                    "       }",
+                "       ↳ 가입 시기 : 2025-01-01",
+            ])
+        })
     })
 
-    describe("ITDOC_DEBUG 환경변수가 ", () => {
+    context("ITDOC_DEBUG 환경변수가 ", () => {
         it("설정되지 않으면 로그레벨이 4가 된다.", async () => {
             delete process.env.ITDOC_DEBUG
             const { default: logger } = await import("../../../config/logger?" + Date.now())

--- a/lib/__tests__/unit/config/logger.test.ts
+++ b/lib/__tests__/unit/config/logger.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "chai"
+import * as sinon from "sinon"
+import chalk from "chalk"
+import logger from "../../../config/logger"
+
+describe("logger 는", () => {
+    let consoleStub: sinon.SinonStub
+
+    beforeEach(() => {
+        consoleStub = sinon.stub(console, "log")
+    })
+
+    afterEach(() => {
+        consoleStub.restore()
+    })
+
+    it("INFO 테스트", () => {
+        logger.info(
+            "회원 가입 성공",
+            {
+                username: "penekhun",
+                name: "MoonSeonghun",
+            },
+            "가입 시기 : 2025-01-01",
+        )
+
+        const [labelLine, ...extraLines] = consoleStub.getCalls().map((c) => c.args[0])
+
+        expect(labelLine).to.equal(
+            chalk.bgBlue(chalk.white.bold("[INFO ]")) + " " + chalk.blue("회원 가입 성공"),
+        )
+
+        expect(extraLines).to.deep.equal([
+            "       ↳ {\n" +
+                '         "username": "penekhun",\n' +
+                '         "name": "MoonSeonghun"\n' +
+                "       }",
+            "       ↳ 가입 시기 : 2025-01-01",
+        ])
+    })
+
+    describe("ITDOC_DEBUG 환경변수가 ", () => {
+        it("설정되지 않으면 로그레벨이 4가 된다.", async () => {
+            delete process.env.ITDOC_DEBUG
+            const { default: logger } = await import("../../../config/logger?" + Date.now())
+            expect(logger.level).to.equal(4)
+        })
+
+        it("설정되면 로그레벨이 0이 된다.", async () => {
+            process.env.ITDOC_DEBUG = "true"
+            const { default: logger } = await import("../../../config/logger?" + Date.now())
+            expect(logger.level).to.equal(0)
+            delete process.env.ITDOC_DEBUG
+        })
+    })
+})

--- a/lib/__tests__/unit/config/logger.test.ts
+++ b/lib/__tests__/unit/config/logger.test.ts
@@ -43,7 +43,7 @@ describe("logger 는", () => {
         const [labelLine, ...extraLines] = consoleStub.getCalls().map((c) => c.args[0])
 
         expect(labelLine).to.equal(
-            chalk.bgBlue(chalk.white.bold("[INFO ]")) + " " + chalk.blue("회원 가입 성공"),
+            chalk.bgBlue(chalk.white.bold("[INFO]")) + "  " + chalk.blue("회원 가입 성공"),
         )
 
         expect(extraLines).to.deep.equal([

--- a/lib/config/LoggerInterface.ts
+++ b/lib/config/LoggerInterface.ts
@@ -17,6 +17,7 @@
 export interface LoggerInterface {
     debug: (message: string | Error, ...extra: unknown[]) => void
     info: (message: string | Error, ...extra: unknown[]) => void
+    box: (message: string) => void
     warn: (message: string | Error, ...extra: unknown[]) => void
     error: (message: string | Error, ...extra: unknown[]) => void
 

--- a/lib/config/LoggerInterface.ts
+++ b/lib/config/LoggerInterface.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface LoggerInterface {
+    debug: (message: string | Error, ...extra: unknown[]) => void
+    info: (message: string | Error, ...extra: unknown[]) => void
+    warn: (message: string | Error, ...extra: unknown[]) => void
+    error: (message: string | Error, ...extra: unknown[]) => void
+
+    level?: number
+}

--- a/lib/config/logger.ts
+++ b/lib/config/logger.ts
@@ -21,7 +21,6 @@ import chalk from "chalk"
 import { LoggerInterface } from "./LoggerInterface"
 
 const DEFAULT_LOG_LEVEL = process.env.ITDOC_DEBUG ? 0 : 4
-
 const levels = {
     DEBUG: {
         color: chalk.gray,
@@ -39,7 +38,8 @@ const levels = {
         color: chalk.red.bold,
         bgColor: chalk.bgRed.white.bold,
     },
-}
+} as const
+const MAX_LOG_LEVEL_LABEL_LENGTH = Math.max(...Object.keys(levels).map((key) => key.length))
 
 const customReporter: ConsolaReporter = {
     log(logObj: LogObject) {
@@ -47,11 +47,13 @@ const customReporter: ConsolaReporter = {
         const levelKey = type.toUpperCase() as keyof typeof levels
         const meta = levels[levelKey]
 
-        const levelText = `[${levelKey.padEnd(5)}]`
+        const levelText = `[${levelKey}]`
         const styledLevel = meta?.bgColor?.(levelText) ?? levelText
 
+        const paddingLength = MAX_LOG_LEVEL_LABEL_LENGTH - levelKey.length
+
         const [message, ...extra] = args
-        console.log(`${styledLevel} ${message}`)
+        console.log(`${styledLevel}${" ".repeat(paddingLength)} ${message}`)
 
         if (extra.length > 0) {
             const formattedExtra = formatExtra(extra)

--- a/lib/config/logger.ts
+++ b/lib/config/logger.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable no-console */
+
+import { ConsolaReporter, createConsola, LogObject } from "consola"
+import chalk from "chalk"
+import { LoggerInterface } from "./LoggerInterface"
+
+const DEFAULT_LOG_LEVEL = process.env.ITDOC_DEBUG ? 0 : 4
+
+const levels = {
+    DEBUG: {
+        color: chalk.gray,
+        bgColor: chalk.bgGray.black.bold,
+    },
+    INFO: {
+        color: chalk.blue,
+        bgColor: chalk.bgBlue.white.bold,
+    },
+    WARNING: {
+        color: chalk.yellow,
+        bgColor: chalk.bgYellow.black.bold,
+    },
+    ERROR: {
+        color: chalk.red.bold,
+        bgColor: chalk.bgRed.white.bold,
+    },
+}
+
+const customReporter: ConsolaReporter = {
+    log(logObj: LogObject) {
+        const { type, args } = logObj
+        const levelKey = type.toUpperCase() as keyof typeof levels
+        const meta = levels[levelKey]
+
+        const levelText = `[${levelKey.padEnd(5)}]`
+        const styledLevel = meta?.bgColor?.(levelText) ?? levelText
+
+        const [message, ...extra] = args
+        console.log(`${styledLevel} ${message}`)
+
+        if (extra.length > 0) {
+            const formattedExtra = formatExtra(extra)
+            for (const line of formattedExtra) {
+                console.log(`       ${line}`)
+            }
+        }
+    },
+}
+
+const formatLog = (levelKey: keyof typeof levels, message: string | Error): string => {
+    const level = levels[levelKey]
+    const text = `${message instanceof Error ? message.message : message}`
+    return level.color(text)
+}
+
+const formatExtra = (extra: unknown[]): string[] => {
+    return extra.map((item) => {
+        if (typeof item === "string") return `↳ ${item}`
+
+        try {
+            const pretty = JSON.stringify(item, null, 2) // 2-space indent
+            return `↳ ${pretty.split("\n").join("\n       ")}`
+        } catch {
+            return `↳ ${String(item)}`
+        }
+    })
+}
+
+const consolaInstance = createConsola({
+    level: DEFAULT_LOG_LEVEL,
+    reporters: [customReporter],
+})
+
+const logger: LoggerInterface = {
+    debug: (msg, ...extra) => consolaInstance.debug(formatLog("DEBUG", msg), ...extra),
+    info: (msg, ...extra) => consolaInstance.info(formatLog("INFO", msg), ...extra),
+    warn: (msg, ...extra) => consolaInstance.warn(formatLog("WARNING", msg), ...extra),
+    error: (msg, ...extra) => consolaInstance.error(formatLog("ERROR", msg), ...extra),
+    level: consolaInstance.level,
+}
+
+export default logger

--- a/lib/config/logger.ts
+++ b/lib/config/logger.ts
@@ -16,7 +16,7 @@
 
 /* eslint-disable no-console */
 
-import { ConsolaReporter, createConsola, LogObject } from "consola"
+import { ConsolaReporter, createConsola, LogObject, consola as defaultConsola } from "consola"
 import chalk from "chalk"
 import { LoggerInterface } from "./LoggerInterface"
 
@@ -44,6 +44,8 @@ const MAX_LOG_LEVEL_LABEL_LENGTH = Math.max(...Object.keys(levels).map((key) => 
 const customReporter: ConsolaReporter = {
     log(logObj: LogObject) {
         const { type, args } = logObj
+        if (type === "box") return
+
         const levelKey = type.toUpperCase() as keyof typeof levels
         const meta = levels[levelKey]
 
@@ -83,17 +85,18 @@ const formatExtra = (extra: unknown[]): string[] => {
     })
 }
 
-const consolaInstance = createConsola({
+const itdocLoggerInstance = createConsola({
     level: DEFAULT_LOG_LEVEL,
     reporters: [customReporter],
 })
 
 const logger: LoggerInterface = {
-    debug: (msg, ...extra) => consolaInstance.debug(formatLog("DEBUG", msg), ...extra),
-    info: (msg, ...extra) => consolaInstance.info(formatLog("INFO", msg), ...extra),
-    warn: (msg, ...extra) => consolaInstance.warn(formatLog("WARN", msg), ...extra),
-    error: (msg, ...extra) => consolaInstance.error(formatLog("ERROR", msg), ...extra),
-    level: consolaInstance.level,
+    debug: (msg, ...extra) => itdocLoggerInstance.debug(formatLog("DEBUG", msg), ...extra),
+    info: (msg, ...extra) => itdocLoggerInstance.info(formatLog("INFO", msg), ...extra),
+    box: (msg) => defaultConsola.box(msg),
+    warn: (msg) => itdocLoggerInstance.warn(formatLog("WARN", msg)),
+    error: (msg, ...extra) => itdocLoggerInstance.error(formatLog("ERROR", msg), ...extra),
+    level: itdocLoggerInstance.level,
 }
 
 export default logger

--- a/lib/config/logger.ts
+++ b/lib/config/logger.ts
@@ -31,7 +31,7 @@ const levels = {
         color: chalk.blue,
         bgColor: chalk.bgBlue.white.bold,
     },
-    WARNING: {
+    WARN: {
         color: chalk.yellow,
         bgColor: chalk.bgYellow.black.bold,
     },
@@ -89,7 +89,7 @@ const consolaInstance = createConsola({
 const logger: LoggerInterface = {
     debug: (msg, ...extra) => consolaInstance.debug(formatLog("DEBUG", msg), ...extra),
     info: (msg, ...extra) => consolaInstance.info(formatLog("INFO", msg), ...extra),
-    warn: (msg, ...extra) => consolaInstance.warn(formatLog("WARNING", msg), ...extra),
+    warn: (msg, ...extra) => consolaInstance.warn(formatLog("WARN", msg), ...extra),
     error: (msg, ...extra) => consolaInstance.error(formatLog("ERROR", msg), ...extra),
     level: consolaInstance.level,
 }

--- a/lib/dsl/test-builders/RootBuilder.ts
+++ b/lib/dsl/test-builders/RootBuilder.ts
@@ -21,6 +21,14 @@ import { AbstractTestBuilder } from "./AbstractTestBuilder"
  * RootBuilder 클래스는 API 테스트의 시작점입니다.
  */
 export class RootBuilder extends AbstractTestBuilder {
+    /**
+     * prettyPrint 설정값을 true로 설정합니다.
+     */
+    public prettyPrint(): this {
+        this.config.prettyPrint = true
+        return this
+    }
+
     public req(): RequestBuilder {
         return new RequestBuilder(this.config, this.method, this.url, this.app)
     }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "ci": "pnpm run prettier:check && pnpm run lint && pnpm run test && pnpm run build",
         "clean": "rimraf build",
         "postinstall": "husky",
-        "lint": "eslint ./lib",
+        "lint": "eslint .",
         "lint-staged": "lint-staged",
         "prepare": "husky && husky install",
         "prettier": "prettier \"{lib,__{tests}__}/**/*.{ts,mts}\" --config .prettierrc --write",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,8 @@
         "husky": "^8.0.0",
         "lint-staged": "^15.4.3",
         "prettier": "~3.4",
+        "@types/sinon": "^17.0.2",
+        "sinon": "^20.0.0",
         "rimraf": "^6.0.1",
         "sort-package-json": "^2.15.1",
         "supports-color": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     },
     "dependencies": {
         "@redocly/cli": "^1.34.0",
+        "consola": "^3.4.2",
         "jest": "^29.7.0",
         "mocha": "^11.1.0",
         "openai": "^4.90.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@redocly/cli':
         specifier: ^1.34.0
         version: 1.34.0(ajv@6.12.6)(supports-color@10.0.0)
+      chalk:
+        specifier: ^4.1.2
+        version: 4.1.2
+      consola:
+        specifier: ^3.4.2
+        version: 3.4.2
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.17.24)(supports-color@10.0.0)(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.7.3))
@@ -1409,8 +1415,8 @@ packages:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
     engines: {'0': node >= 6.0}
 
-  consola@3.4.0:
-    resolution: {integrity: sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==}
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
   content-disposition@0.5.4:
@@ -5031,7 +5037,7 @@ snapshots:
       readable-stream: 3.6.2
       typedarray: 0.0.6
 
-  consola@3.4.0: {}
+  consola@3.4.2: {}
 
   content-disposition@0.5.4:
     dependencies:
@@ -7274,7 +7280,7 @@ snapshots:
       bundle-require: 5.1.0(esbuild@0.25.0)
       cac: 6.7.14
       chokidar: 4.0.3
-      consola: 3.4.0
+      consola: 3.4.2
       debug: 4.4.0(supports-color@10.0.0)
       esbuild: 0.25.0
       joycon: 3.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@redocly/cli':
         specifier: ^1.34.0
         version: 1.34.0(ajv@6.12.6)(supports-color@10.0.0)
-      chalk:
-        specifier: ^4.1.2
-        version: 4.1.2
       consola:
         specifier: ^3.4.2
         version: 3.4.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@types/node':
         specifier: ~20
         version: 20.17.24
+      '@types/sinon':
+        specifier: ^17.0.2
+        version: 17.0.4
       '@types/supertest':
         specifier: ^6.0.2
         version: 6.0.2
@@ -87,6 +90,9 @@ importers:
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
+      sinon:
+        specifier: ^20.0.0
+        version: 20.0.0
       sort-package-json:
         specifier: ^2.15.1
         version: 2.15.1
@@ -948,6 +954,12 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
+  '@sinonjs/fake-timers@13.0.5':
+    resolution: {integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==}
+
+  '@sinonjs/samsam@8.0.2':
+    resolution: {integrity: sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==}
+
   '@tsconfig/node10@1.0.11':
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
 
@@ -1022,6 +1034,12 @@ packages:
 
   '@types/node@20.17.24':
     resolution: {integrity: sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==}
+
+  '@types/sinon@17.0.4':
+    resolution: {integrity: sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==}
+
+  '@types/sinonjs__fake-timers@8.1.5':
+    resolution: {integrity: sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -1561,6 +1579,10 @@ packages:
 
   diff@5.2.0:
     resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
+    engines: {node: '>=0.3.1'}
+
+  diff@7.0.0:
+    resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
     engines: {node: '>=0.3.1'}
 
   dompurify@3.2.4:
@@ -2426,6 +2448,10 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.get@4.4.2:
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
+
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
@@ -3145,6 +3171,9 @@ packages:
   simple-websocket@9.1.0:
     resolution: {integrity: sha512-8MJPnjRN6A8UCp1I+H/dSFyjwJhp6wta4hsVRhjf8w9qBHRzxYt14RaOcjvQnhD1N4yKOddEjflwMnQM4VtXjQ==}
 
+  sinon@20.0.0:
+    resolution: {integrity: sha512-+FXOAbdnj94AQIxH0w1v8gzNxkawVvNqE3jUzRLptR71Oykeu2RrQXXl/VQjKay+Qnh73fDt/oDfMo6xMeDQbQ==}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -3431,6 +3460,10 @@ packages:
 
   type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
+
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
 
   type-fest@0.20.2:
@@ -4516,6 +4549,16 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@sinonjs/fake-timers@13.0.5':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
+  '@sinonjs/samsam@8.0.2':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      lodash.get: 4.4.2
+      type-detect: 4.1.0
+
   '@tsconfig/node10@1.0.11': {}
 
   '@tsconfig/node12@1.0.11': {}
@@ -4600,6 +4643,12 @@ snapshots:
   '@types/node@20.17.24':
     dependencies:
       undici-types: 6.19.8
+
+  '@types/sinon@17.0.4':
+    dependencies:
+      '@types/sinonjs__fake-timers': 8.1.5
+
+  '@types/sinonjs__fake-timers@8.1.5': {}
 
   '@types/stack-utils@2.0.3': {}
 
@@ -5151,6 +5200,8 @@ snapshots:
   diff@4.0.2: {}
 
   diff@5.2.0: {}
+
+  diff@7.0.0: {}
 
   dompurify@3.2.4:
     optionalDependencies:
@@ -6250,6 +6301,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.get@4.4.2: {}
+
   lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
@@ -7000,6 +7053,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  sinon@20.0.0:
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 13.0.5
+      '@sinonjs/samsam': 8.0.2
+      diff: 7.0.0
+      supports-color: 7.2.0
+
   sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
@@ -7314,6 +7375,8 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-detect@4.0.8: {}
+
+  type-detect@4.1.0: {}
 
   type-fest@0.20.2: {}
 

--- a/script/llm/index.ts
+++ b/script/llm/index.ts
@@ -22,6 +22,9 @@ import { fileURLToPath } from "url"
 import chalk from "chalk"
 import getItdocPrompt from "./prompt/index.js"
 
+/* TODO: no-console 해제 후, console.log() 제거. logger를 사용하도록 변경 해야함. */
+/* eslint-disable no-console */
+
 const __filename: string = fileURLToPath(import.meta.url)
 const __dirname: string = path.dirname(__filename)
 dotenv.config({ path: path.join(__dirname, "../../.env") })

--- a/script/makedocs/index.ts
+++ b/script/makedocs/index.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+/* TODO: no-console 해제 후, console.log() 제거. logger를 사용하도록 변경 해야함. */
+/* eslint-disable no-console */
+
 import { execSync } from "child_process"
 import { existsSync, mkdirSync } from "fs"
 import { fileURLToPath } from "url"


### PR DESCRIPTION
# 참고

#42 PR 닫고, 다시 올렸습니당. 참고해주세욥

# Changes

- prettyPrint 기능 활성화 부분 추가
- logger로 `consola`를 적용
- 더이상 `console`을 사용할 수 없도록 eslint 규칙 추가
  - 더불어 여태껏 eslint가 `lib/` 경로에만 적용되고 있었습니다. 프로젝트 전역에 적용되도록 변경했습니다.
    - 이 과정에서 발생한 기존 console.log 등의 eslint errror는 임시 주석으로 해결했으니, 각 작업자들은 적절하게 리팩토링을 진행해주세요.
      - @wnghdcjfe @cjs1301  아래 커밋을 한번 꼭 봐주시고, 본인들 코드에서 수정하실 게 있다면 변경해주세욥 (별도의 브랜치 혹은 해당 PR에서 작업해도 됨)
        -  77e455790ffb0a25bf427c15b121a7b0e8c8dab5



## 사용 예시

```javascript
import logger from "../../config/logger"

// 기본 string + 빈 객체
logger.info("API 요청을 시작 합니다", "요청 값", {
    userId: "test-user",
})

// 숫자 포함된 단순 객체
logger.debug("요청 파라미터", {
    userId: 123,
    includePosts: true,
})

// 중첩된 객체 구조
logger.warn("응답 시간 지연", {
    route: "/api/data",
    thresholdMs: 3000,
    actualMs: 4820,
    context: {
        retry: 1,
        region: "ap-northeast-2",
    },
})

// 에러 객체 + 디버그용 부가 정보
logger.error(new Error("DB 연결 실패"), {
    db: "users",
    host: "localhost",
    options: {
        reconnect: true,
        timeout: 5000,
    },
})

// 여러 인자: string + string + object
logger.error("요청 실패", "retry 중단됨", {
    requestId: "abc-123-def",
    fatal: true,
})
```

<img width="418" alt="image" src="https://github.com/user-attachments/assets/df44c671-2e6f-4826-a981-9aae64780470" />
 

close #15 
close #30 
- 프로그래스바는 진행하지 않았는데, 필요하면 뭐 붙이던가 하면 될듯합닙다