### PR TITLE
68번 이슈 해결

### DIFF
--- a/examples/express/__tests__/expressApp.test.js
+++ b/examples/express/__tests__/expressApp.test.js
@@ -19,7 +19,7 @@ describeAPI(
                 .prettyPrint()
                 .req()
                 .body({
-                    username: "penekhun",
+                    username: field("사용자 이름", "username"),
                     password: field("패스워드", "P@ssw0rd123!@#"),
                 })
                 .res()


### PR DESCRIPTION
`/signup` API의 required는 `selectRepresentativeResult`에 의해 정해진 `TestSuite`에서 명시된 정보로 결정됨.

```ts
    (apiDoc) => {
        itDoc("회원가입 성공", async () => {
            await apiDoc
                .test()
                .prettyPrint()
                .req()
                .body({
                    username: "penekhun"
                    password: field("패스워드", "P@ssw0rd123!@#"),
                })
                .res()
                .status(HttpStatus.CREATED)
        })
```

따라서 `/signup` API에서 username 에 required를 적용하려면,
위 코드에서 username 부분을 field()로 감싸야 함.

-----

closed #68 

