### PR TITLE
docs: 문서 페이지 링크 구성 수정

### DIFF
--- a/itdoc-doc/docs/guides/quick-start.mdx
+++ b/itdoc-doc/docs/guides/quick-start.mdx
@@ -255,11 +255,7 @@ an `itdoc` field to your `package.json` file.
 This configuration allows you to control the basic information of the generated OpenAPI document and
 change the output file location.
 
-## What's Next?
-
-After completing this quick start guide, you can:
-
-1. Check out the [full API reference](../api-reference/reference)
-
 For more detailed examples, check out the examples in the
 [GitHub repository](https://github.com/do-pa/itdoc/tree/main/examples).
+
+## What's Next?

--- a/itdoc-doc/docs/intro.mdx
+++ b/itdoc-doc/docs/intro.mdx
@@ -116,11 +116,7 @@ include:
 - **HTTP-Related Constants:** Provides enumerations (`HttpMethod`, `HttpStatus`) for managing HTTP
   methods and status codes.
 
-## What's Next?
-
-After completing this quick start guide, you can:
-
-1. Check out the [full API reference](./api-reference/reference)
-
 For more detailed examples, check out the examples in the
 [GitHub repository](https://github.com/do-pa/itdoc/tree/main/examples).
+
+## What's Next?

--- a/itdoc-doc/i18n/ko/docusaurus-plugin-content-docs/current/guides/quick-start.mdx
+++ b/itdoc-doc/i18n/ko/docusaurus-plugin-content-docs/current/guides/quick-start.mdx
@@ -252,11 +252,7 @@ itdoc을 사용하여 API를 문서화하는 테스트 파일을 작성하세요
 
 이 설정을 통해 생성되는 OpenAPI 문서의 기본 정보를 제어하고, 출력 파일의 위치를 변경할 수 있습니다.
 
-## 다음 단계
-
-이 빠른 시작 가이드를 완료한 후에는 다음과 같은 작업을 할 수 있습니다:
-
-1. [전체 API 참조](../api-reference/reference) 확인하기
-
 더 자세한 예제는 [GitHub 저장소](https://github.com/do-pa/itdoc/tree/main/examples)의 예제를
 확인하세요.
+
+## 다음 단계

--- a/itdoc-doc/i18n/ko/docusaurus-plugin-content-docs/current/intro.mdx
+++ b/itdoc-doc/i18n/ko/docusaurus-plugin-content-docs/current/intro.mdx
@@ -114,11 +114,7 @@ import TabItem from "@theme/TabItem"
 - **HTTP 관련 상수:** HTTP 메서드 및 상태 코드를 관리하기 위한 열거형 (`HttpMethod`, `HttpStatus`)을
   제공합니다.
 
-## 다음 단계
-
-이 빠른 시작 가이드를 완료한 후 다음을 수행할 수 있습니다:
-
-1. [full API reference](./api-reference/reference) 확인
-
 더 자세한 예제는 [GitHub repository](https://github.com/do-pa/itdoc/tree/main/examples)에서 확인할
 수 있습니다.
+
+## 다음 단계


### PR DESCRIPTION
국제화 지원을 위한 언어별 경로 구성에서 
docusaurus자체 라우트 구성을 잘못하는 문제가 있어 일괄적으로 문서 구성을 변경했습니다.