### PR TITLE
fix: itdoc install 오류 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
         "build": "pnpm run clean && tsup",
         "ci": "pnpm run prettier:check && pnpm run lint && pnpm run test && pnpm run build",
         "clean": "rimraf build",
-        "postinstall": "husky",
         "lint": "eslint .",
         "lint-staged": "lint-staged",
         "prepare": "husky && husky install",


### PR DESCRIPTION
npm install 설치 오류 해결.
실제 모의배포로 테스트 완료
>  "penekdoc-test": "^0.1.7",

----

closed #103 