### PR TITLE
일부 환경에서 itdoc이 제대로 실행되지 않는 문제 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,8 +80,6 @@
     "dependencies": {
         "@redocly/cli": "^1.34.0",
         "consola": "^3.4.2",
-        "jest": "^29.7.0",
-        "mocha": "^11.1.0",
         "openai": "^4.90.0",
         "supertest": "^7.0.0"
     },

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
         "@redocly/cli": "^1.34.0",
         "consola": "^3.4.2",
         "openai": "^4.90.0",
-        "supertest": "^7.0.0"
+        "supertest": "^7.0.0",
+        "chalk": "^4.1.2"
     },
     "devDependencies": {
         "@eslint/js": "~9.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@redocly/cli':
         specifier: ^1.34.0
         version: 1.34.0(ajv@8.17.1)(supports-color@10.0.0)
+      chalk:
+        specifier: ^4.1.2
+        version: 4.1.2
       consola:
         specifier: ^3.4.2
         version: 3.4.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,10 +15,10 @@ importers:
         specifier: ^3.4.2
         version: 3.4.2
       jest:
-        specifier: ^29.7.0
+        specifier: ^29.0.0
         version: 29.7.0(@types/node@20.17.24)(supports-color@10.0.0)(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.7.3))
       mocha:
-        specifier: ^11.1.0
+        specifier: ^11.0.0
         version: 11.1.0
       openai:
         specifier: ^4.90.0

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     clean: true,
 
     // 번들에서 제외할 외부 의존성
-    external: ["express", "mocha", "jest"],
+    external: ["express", "mocha", "jest", "chalk"],
 
     // 번들 출력 디렉토리
     outDir: "build",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     clean: true,
 
     // 번들에서 제외할 외부 의존성
-    external: ["express", "mocha", "jest", "chalk"],
+    external: ["express", "mocha", "jest", "chalk", "supertest"],
 
     // 번들 출력 디렉토리
     outDir: "build",
@@ -45,5 +45,5 @@ export default defineConfig({
     metafile: false,
 
     // 항상 번들에 포함할 패키지
-    noExternal: ["supertest", "consola"],
+    noExternal: ["consola"],
 })


### PR DESCRIPTION
초기에 npm package와 tsup에 살짝 무지했던 것 같습니다.
`tsup.config.ts`에서 배포시에 어떤것을 번들러에 포함시킬지 여부를 정할 수 있는데요.

제 생각으론, 번들러에 포함시키지 않으면
> // 항상 번들에 포함할 패키지
> ex: noExternal: ["supertest"],

#43 -> 예전엔 사용자가 직접 설치해야하는줄 알았습니다 ㅎㅎ;
하지만 실제로는 itdoc `dependencies`에 명시해두면 자동으로 설치되더군요.

그리고 번들러에 포함시킬 패키지는 조심스럽게 정해야 함을 알게되었네용.
그 패키지도 트랜스파일링을 시켜야 하는데, 제대로 안될수도 있으니깐요.
이것때문에 #140 이 발생했던 것으로 파악했습니다.

# Changes

- 번들링과 `package.json` 종속성 정보 수정

# Note

별도의 프로젝트로 직접 배포해서 설치 및 실행 테스트 해봤습니다.
> "penekdoc-test": "0.2.2",

# Relate

closed #140 