### PR TITLE
배포시 next tag가 아닌 latest로 배포되도록 변경

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -49,6 +49,6 @@ jobs:
         run: pnpm install
       - name: Build
         run: pnpm build
-      - run: pnpm publish --provenance --access public --tag=next
+      - run: pnpm publish --provenance --access public --tag=latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
지금은 프로젝트 초기라 다소 변경사항이 많은데요.

next 태그로 배포될 경우,틸트나 캐럿(~, ^)으로 해당 버전이 설치되지 않습니다.
사용자가 직접 버전을 명시하지 해야하는데, 당장 버그가 많긴해서 latest로 배포되는게 당장은 좋을 것 같습니다 (ex : 0.2.1)

추후에 stable한 버전이 나온다면 next로 다시 배포되도록 변경되는게 좋겠네요

---


closed #138 