### PR TITLE
feat: itdoc CLI 도입 및 generate 명령어 연동

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Command } from "commander"
+import { createRequire } from "module"
+import { fileURLToPath } from "url"
+import path, { dirname, join } from "path"
+import generateByLLM from "../script/llm/index"
+import logger from "../lib/config/logger"
+
+const require = createRequire(import.meta.url)
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const { version, description } = require(join(__dirname, "..", "..", "package.json"))
+
+const args = process.argv.slice(2)
+const isRootHelp = args.length === 0 || args[0] === "--help" || args[0] === "-h"
+if (isRootHelp) {
+    logger.box("ITDOC CLI")
+}
+const program = new Command()
+program
+    .name("itdoc")
+    .description(description)
+    .version(`Version ${version}`, "-v, --version", "버전 정보 출력")
+
+program
+    .command("generate")
+    .description("LLM 기반 ITDOC 테스트 코드를 생성합니다.")
+    .option("-p, --path <testspect>", "테스트 스펙 마크다운 경로를 지정합니다", undefined)
+    .option("-e, --env <envPath>", ".env 파일 경로를 지정합니다", undefined)
+    .action((options: { path?: string; env?: string }) => {
+        // .env 로드
+        const envPath = options.env
+            ? path.isAbsolute(options.env)
+                ? options.env
+                : path.resolve(process.cwd(), options.env)
+            : path.resolve(process.cwd(), ".env")
+
+        // testspec 경로 처리
+        if (!options.path) {
+            logger.error("테스트 스펙이 담긴 경로를 지정해주세요. (-p 옵션 사용)")
+            logger.info("ex) itdoc generate -p ../md/testspec.md")
+            logger.info("ex) itdoc generate --path ../md/testspec.md")
+            process.exit(1)
+        }
+        const specPath = options.path
+        const resolvedPath = path.isAbsolute(specPath)
+            ? specPath
+            : path.resolve(process.cwd(), specPath)
+
+        generateByLLM(resolvedPath, envPath)
+    })
+
+program.parse(process.argv)
+
+if (!args.length) {
+    program.outputHelp()
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,7 @@ export default tseslint.config(
             "itdoc-doc/**",
             "**/*.md",
             "**/*.mdx",
+            "output/**",
         ],
     },
     // ESLint 기본 추천 규칙

--- a/examples/express-ts/src/__tests__/product.test.ts
+++ b/examples/express-ts/src/__tests__/product.test.ts
@@ -11,7 +11,7 @@ describe("Product API Tests", () => {
             description: "Retrieves a specific product by its ID.",
         },
         app,
-        (apiDoc) => {
+        (apiDoc: any) => {
             itDoc("should return a specific product", async () => {
                 apiDoc
                     .test()
@@ -38,7 +38,7 @@ describe("Product API Tests", () => {
             description: "Creates a new product with the provided information.",
         },
         app,
-        (apiDoc) => {
+        (apiDoc: any) => {
             itDoc("should create a new product", async () => {
                 apiDoc
                     .test()
@@ -69,7 +69,7 @@ describe("Product API Tests", () => {
             description: "Updates an existing product with the provided information.",
         },
         app,
-        (apiDoc) => {
+        (apiDoc: any) => {
             itDoc("should update a product", async () => {
                 apiDoc
                     .test()
@@ -101,7 +101,7 @@ describe("Product API Tests", () => {
             description: "Deletes a product by its ID.",
         },
         app,
-        (apiDoc) => {
+        (apiDoc: any) => {
             itDoc("should delete a product", async () => {
                 apiDoc
                     .test()

--- a/examples/express-ts/src/index.ts
+++ b/examples/express-ts/src/index.ts
@@ -13,11 +13,11 @@ app.use(express.json())
 
 app.use("/api/products", productRoutes)
 
-app.get("/health", (req, res) => {
+app.get("/health", (_req, res) => {
     res.status(200).json({ status: "OK", message: "Server is running" })
 })
 
-app.use((err: Error, req: express.Request, res: express.Response, next: express.NextFunction) => {
+app.use((err: Error, _req: express.Request, res: express.Response) => {
     console.error(err.stack)
     res.status(500).json({ error: "Something went wrong!" })
 })

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
         "consola": "^3.4.2",
         "dot": "^1.1.3",
         "dotenv": "^16.3.1",
+        "fast-glob": "^3.3.3",
         "openai": "^4.90.0",
         "supertest": "^7.0.0",
         "widdershins": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
     "version": "0.2.1",
     "description": "Test-driven documentation for RESTful services",
     "license": "Apache-2.0",
+    "bin": {
+        "itdoc": "./build/bin/index.js"
+    },
     "author": {
         "name": "Moon Seonghun",
         "email": "penekhun@gamil.com",
@@ -81,8 +84,10 @@
         "@redocly/cli": "^1.34.0",
         "@redocly/openapi-core": "^1.34.2",
         "chalk": "^4.1.2",
+        "commander": "^13.1.0",
         "consola": "^3.4.2",
         "dot": "^1.1.3",
+        "dotenv": "^16.3.1",
         "openai": "^4.90.0",
         "supertest": "^7.0.0",
         "widdershins": "^4.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,12 +17,18 @@ importers:
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
+      commander:
+        specifier: ^13.1.0
+        version: 13.1.0
       consola:
         specifier: ^3.4.2
         version: 3.4.2
       dot:
         specifier: ^1.1.3
         version: 1.1.3
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.4.7
       jest:
         specifier: ^29.0.0
         version: 29.7.0(@types/node@20.17.24)(supports-color@10.0.0)(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.7.3))
@@ -4796,7 +4802,7 @@ packages:
 
   formidable@2.1.3:
     resolution: {integrity: sha512-vDI5JjeALeGXpyL8v71ZG2VgHY5zD6qg1IvypU7aJCYvREZyhawrYJxMdsWO+m5DIGLiMiDH71yEN8RO4wQAMQ==}
-    deprecated: 'ACTION REQUIRED: SWITCH TO v3 - v1 and v2 are VULNERABLE AND DEPRECATED FOR OVER 2 YEARS! Use formidable@latest or try formidable-mini for fresh projects'
+    deprecated: 'ATTENTION: please upgrade to v3! The v1 and v2 versions are pretty old and deprecated'
 
   formidable@3.5.2:
     resolution: {integrity: sha512-Jqc1btCy3QzRbJaICGwKcBfGWuLADRerLzDqi2NwSt/UkXLsHJw2TVResiaoBufHVHy9aSgClOHCeJsSsFLTbg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       dotenv:
         specifier: ^16.3.1
         version: 16.4.7
+      fast-glob:
+        specifier: ^3.3.3
+        version: 3.3.3
       jest:
         specifier: ^29.0.0
         version: 29.7.0(@types/node@20.17.24)(supports-color@10.0.0)(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.7.3))

--- a/script/llm/envLoader.ts
+++ b/script/llm/envLoader.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from "fs"
+import path from "path"
+import logger from "../../lib/config/logger"
+
+/**
+ *
+ * @param envPath
+ */
+export function resolveEnv(envPath?: string): string {
+    const actual =
+        envPath && path.isAbsolute(envPath)
+            ? envPath
+            : path.resolve(process.cwd(), envPath || ".env")
+    if (!fs.existsSync(actual)) {
+        logger.error(`.env 파일이 없습니다: ${actual}`)
+        process.exit(1)
+    }
+    logger.info(`env 파일 로드: ${actual}`)
+    return actual
+}

--- a/script/llm/index.ts
+++ b/script/llm/index.ts
@@ -20,6 +20,9 @@ import path from "path"
 import dotenv from "dotenv"
 import getItdocPrompt from "./prompt/index"
 import logger from "../../lib/config/logger"
+import { loadSpec } from "./specLoader"
+import { resolveEnv } from "./envLoader"
+import { getOutputPath } from "../../lib/config/getOutputPath"
 
 /**
  * LLM을 호출해 itdoc 테스트스크립트를 작성합니다.
@@ -27,13 +30,6 @@ import logger from "../../lib/config/logger"
  * @param {string} content - 처리할 마크다운 콘텐츠
  * @param {boolean} isEn - 영어 출력을 원할 경우 true
  * @returns {Promise<string|null>} 생성된 문서 문자열, 오류 발생 시 null 반환
- */
-
-/**
- *
- * @param openai
- * @param content
- * @param isEn
  */
 async function makedocLLM(openai: OpenAI, content: string, isEn: boolean): Promise<string | null> {
     try {
@@ -60,75 +56,31 @@ async function makedocLLM(openai: OpenAI, content: string, isEn: boolean): Promi
  * @param {string} [envPath] - 환경 변수 파일(.env) 경로(절대/상대)
  * @returns {Promise<void>}
  */
+
+/**
+ *
+ * @param testspecPath
+ * @param envPath
+ */
 export default async function generateByLLM(
     testspecPath?: string,
     envPath?: string,
 ): Promise<void> {
-    const actualEnvPath = envPath
-        ? path.isAbsolute(envPath)
-            ? envPath
-            : path.resolve(process.cwd(), envPath)
-        : path.resolve(process.cwd(), ".env")
-
-    if (!fs.existsSync(actualEnvPath)) {
-        logger.error(`.env 파일이 존재하지 않습니다: ${actualEnvPath}`)
-        process.exit(1)
-    } else {
-        logger.info(`GPT API키가 있는 env파일을 로드합니다. ${actualEnvPath}`)
-    }
-
-    dotenv.config({ path: actualEnvPath })
+    const actualEnv = resolveEnv(envPath)
+    dotenv.config({ path: actualEnv })
     if (!process.env.OPENAI_API_KEY) {
         logger.error("환경 변수 OPENAI_API_KEY가 설정되어 있지 않습니다.")
         process.exit(1)
     }
     const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+    const specContent = loadSpec(testspecPath)
 
-    const defaultSpec = path.join(process.cwd(), "md", "testspec.md")
-    const actualSpec = testspecPath
-        ? path.isAbsolute(testspecPath)
-            ? testspecPath
-            : path.resolve(process.cwd(), testspecPath)
-        : defaultSpec
-    if (!fs.existsSync(actualSpec)) {
-        logger.error(`테스트스펙파일이 존재하지 않습니다: ${actualSpec}`)
-        logger.info(`다음의 경로에 테스트스펙파일을 생성해주셔야 합니다. ${actualSpec}`)
-        process.exit(1)
-    } else {
-        logger.info(`테스트스펙파일 경로: ${actualSpec}`)
-    }
-    const content = fs.readFileSync(actualSpec, "utf8")
+    const result = await makedocLLM(openai, specContent, false)
+    if (!result) return
 
-    const packageJsonPath = path.resolve(process.cwd(), "package.json")
-    let outputDir: string
-    try {
-        const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"))
-        if (pkg.itdoc && typeof pkg.itdoc.output === "string") {
-            outputDir = path.resolve(process.cwd(), pkg.itdoc.output)
-            logger.info(`output 경로가 ${pkg.itdoc.output}로 설정됩니다. `)
-        } else {
-            logger.info(
-                `package.json - itdoc - output 경로가 설정되어있지 않습니다. 현재 경로를 기반으로 output 폴더가 설정됩니다.`,
-            )
-            outputDir = path.resolve(process.cwd(), "output")
-        }
-    } catch (err) {
-        logger.error(`package.json 파일을 읽는 중 오류 발생: ${err}`)
-        logger.info(
-            `package.json - itdoc - output 경로가 설정되어있지 않습니다. 현재 경로를 기반으로 output 폴더가 설정됩니다.`,
-        )
-        outputDir = path.resolve(process.cwd(), "output")
-    }
-    if (!fs.existsSync(outputDir)) {
-        fs.mkdirSync(outputDir, { recursive: true })
-        logger.info(`output 디렉토리가 생성되어있지 않아 ${outputDir}를 생성합니다.`)
-    }
-    const filePath = path.resolve(outputDir, "output.js")
-
-    const isEn = false
-    const result = await makedocLLM(openai, content, isEn)
-    if (result) {
-        fs.writeFileSync(filePath, result, "utf8")
-        logger.info(`GPT 기반 테스트 코드 생성 완료: ${filePath}`)
-    }
+    const outputDir = getOutputPath()
+    fs.mkdirSync(outputDir, { recursive: true })
+    const outPath = path.join(outputDir, "output.js")
+    fs.writeFileSync(outPath, result, "utf8")
+    logger.info(`문서 생성 완료: ${outPath}`)
 }

--- a/script/llm/prompt/index.ts
+++ b/script/llm/prompt/index.ts
@@ -32,11 +32,25 @@ const __dirname: string = dirname(__filename)
  * @returns {string} - 생성된 프롬프트 메시지 문자열.
  */
 function getItdocPrompt(content: string, isEn: boolean): string {
-    const itdocExamplePath: string = join(
-        __dirname,
-        "../../examples/express/__tests__/expressApp.test.js",
-    )
-    const itdocExample: string = fs.readFileSync(itdocExamplePath, "utf8")
+    const exampleParts = ["express", "__tests__", "expressApp.test.js"]
+    const baseDirs = [join(__dirname, "..", "examples"), join(__dirname, "..", "..", "examples")]
+    let examplePath: string | undefined
+    for (const base of baseDirs) {
+        const p = join(base, ...exampleParts)
+        if (fs.existsSync(p)) {
+            examplePath = p
+            break
+        }
+    }
+
+    if (!examplePath) {
+        throw new Error(
+            `테스트 예제 파일을 찾을 수 없습니다:\n` +
+                baseDirs.map((b) => join(b, ...exampleParts)).join("\n"),
+        )
+    }
+
+    const itdocExample: string = fs.readFileSync(examplePath, "utf8")
 
     const addmsg: string = isEn
         ? "그리고 반드시 영어로 출력해야 합니다."

--- a/script/llm/prompt/index.ts
+++ b/script/llm/prompt/index.ts
@@ -34,7 +34,7 @@ const __dirname: string = dirname(__filename)
 function getItdocPrompt(content: string, isEn: boolean): string {
     const itdocExamplePath: string = join(
         __dirname,
-        "../../../examples/express/__tests__/expressApp.test.js",
+        "../../examples/express/__tests__/expressApp.test.js",
     )
     const itdocExample: string = fs.readFileSync(itdocExamplePath, "utf8")
 

--- a/script/llm/specLoader.ts
+++ b/script/llm/specLoader.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from "fs"
+import path from "path"
+import logger from "../../lib/config/logger"
+
+/**
+ *
+ * @param specArg
+ */
+export function loadSpec(specArg?: string): string {
+    const defaultPath = path.resolve(process.cwd(), "md/testspec.md")
+    const actual =
+        specArg && path.isAbsolute(specArg)
+            ? specArg
+            : path.resolve(process.cwd(), specArg || defaultPath)
+    if (!fs.existsSync(actual)) {
+        logger.error(`테스트 스펙이 없습니다: ${actual}`)
+        process.exit(1)
+    }
+    logger.info(`테스트 스펙 로드: ${actual}`)
+    return fs.readFileSync(actual, "utf8")
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,65 +1,32 @@
 {
     "compilerOptions": {
         "typeRoots": ["./node_modules/@types", "./lib/types"],
-        // 컴파일 결과물의 JavaScript 버전 설정
         "target": "ES2022",
-
-        // 모듈 시스템 설정 (import/export 문법)
         "module": "ESNext",
-
-        // 사용할 JavaScript API 정의
         "lib": ["ESNext"],
-
-        // .d.ts 파일 생성 여부
         "declaration": true,
-
-        // .d.ts 파일이 생성될 디렉토리
+        "allowJs": true,
         "declarationDir": "./build",
-
-        // 컴파일된 JavaScript 파일이 생성될 디렉토리
         "outDir": "./build",
-
-        // 엄격한 타입 체크 활성화
+        "rootDir": ".",
         "strict": true,
-
-        // CommonJS 모듈을 ES 모듈처럼 import 할 수 있게 함
         "esModuleInterop": true,
-
-        // node_modules의 타입 체크 스킵 (빌드 성능 향상)
         "skipLibCheck": true,
-
-        // 파일명 대소문자 일관성 검사
         "forceConsistentCasingInFileNames": true,
-
-        // 번들러 기반 모듈 해석 사용
         "moduleResolution": "bundler",
-
-        // default import 구문 허용
         "allowSyntheticDefaultImports": true,
-
-        // JSON 모듈 import 지원
         "resolveJsonModule": true,
-
-        // 각 파일을 독립적인 모듈로 처리 (번들러 호환성)
         "isolatedModules": true,
-
-        // 사용하지 않는 지역 변수 에러 처리
         "noUnusedLocals": true,
-
-        // 사용하지 않는 매개변수 에러 처리
         "noUnusedParameters": true,
-
-        // 함수의 모든 경로에서 반환값 필수화
         "noImplicitReturns": true,
-
-        // switch문 fall-through 방지
         "noFallthroughCasesInSwitch": true,
-
-        // 소스맵 생성
-        "sourceMap": true
+        "sourceMap": true,
+        "baseUrl": ".",
+        "paths": {
+            "itdoc": ["lib/dsl/index.ts"]
+        }
     },
-    // 컴파일 대상 파일
-    "include": ["lib/**/*", "eslint.config.mjs", "script/llm/**/*", "script/makedocs/**/*"],
-    // 컴파일 제외 대상
+    "include": ["lib/**/*", "script/**/*", "bin/**/*", "eslint.config.mjs"],
     "exclude": ["node_modules", "build", "**/__tests__/**/*"]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig } from "tsup"
+import fg from "fast-glob"
+import { copyFile, mkdir } from "node:fs/promises"
+import path from "node:path"
 
 export default defineConfig([
     {
@@ -16,6 +19,28 @@ export default defineConfig([
         minify: false,
         metafile: false,
         noExternal: ["consola"],
+
+        // 빌드가 끝난 뒤 onSuccess 훅에서 복사 작업 수행
+        onSuccess: async () => {
+            // examples 폴더 내 모든 파일 중 node_modules 는 제외
+            const entries = await fg("examples/**/*", {
+                dot: true,
+                onlyFiles: true,
+                ignore: ["**/node_modules/**"],
+            })
+
+            // build/examples 폴더 생성
+            await mkdir("build/examples", { recursive: true })
+
+            // 하나씩 복사
+            await Promise.all(
+                entries.map(async (src) => {
+                    const dest = path.join("build", src)
+                    await mkdir(path.dirname(dest), { recursive: true })
+                    await copyFile(src, dest)
+                }),
+            )
+        },
     },
     {
         entry: ["bin/index.ts"],
@@ -27,6 +52,5 @@ export default defineConfig([
         target: "node20",
         platform: "node",
         banner: { js: "#!/usr/bin/env node" },
-        onSuccess: "cp -R examples build/examples",
     },
 ])

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,49 +1,32 @@
 import { defineConfig } from "tsup"
 
-export default defineConfig({
-    // 진입점 설정
-    entry: ["lib/dsl/index.ts"],
-
-    // 출력 형식 설정
-    // ESM과 CommonJS 두 가지 형식으로 번들 생성
-    format: ["esm", "cjs"],
-
-    // TypeScript 타입 정의 파일 생성
-    dts: true,
-
-    // 디버깅을 위한 소스맵 생성
-    sourcemap: true,
-
-    // 빌드 전 dist 디렉토리 정리
-    clean: true,
-
-    // 번들에서 제외할 외부 의존성
-    external: ["express", "mocha", "jest", "chalk", "supertest"],
-
-    // 번들 출력 디렉토리
-    outDir: "build",
-
-    // 대상 Node.js 버전 (20.x)
-    target: "node20",
-
-    // 실행 환경 설정
-    platform: "node",
-
-    // 코드 분할 비활성화
-    // 단일 진입점 사용으로 불필요
-    splitting: false,
-
-    // 트리쉐이킹 활성화
-    // 사용하지 않는 코드 제거
-    treeshake: true,
-
-    // 코드 최소화 비활성화
-    // 개발 편의성 및 빌드 속도 개선
-    minify: false,
-
-    // 빌드 메타데이터 생성 비활성화
-    metafile: false,
-
-    // 항상 번들에 포함할 패키지
-    noExternal: ["consola"],
-})
+export default defineConfig([
+    {
+        entry: ["lib/dsl/index.ts"],
+        format: ["esm", "cjs"],
+        dts: true,
+        sourcemap: true,
+        clean: true,
+        external: ["express", "mocha", "jest", "chalk", "supertest"],
+        outDir: "build",
+        target: "node20",
+        platform: "node",
+        splitting: false,
+        treeshake: true,
+        minify: false,
+        metafile: false,
+        noExternal: ["consola"],
+    },
+    {
+        entry: ["bin/index.ts"],
+        format: ["esm"],
+        dts: false,
+        sourcemap: false,
+        clean: false,
+        outDir: "build/bin",
+        target: "node20",
+        platform: "node",
+        banner: { js: "#!/usr/bin/env node" },
+        onSuccess: "cp -R examples build/examples",
+    },
+])

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -19,20 +19,13 @@ export default defineConfig([
         minify: false,
         metafile: false,
         noExternal: ["consola"],
-
-        // 빌드가 끝난 뒤 onSuccess 훅에서 복사 작업 수행
         onSuccess: async () => {
-            // examples 폴더 내 모든 파일 중 node_modules 는 제외
             const entries = await fg("examples/**/*", {
                 dot: true,
                 onlyFiles: true,
                 ignore: ["**/node_modules/**"],
             })
-
-            // build/examples 폴더 생성
             await mkdir("build/examples", { recursive: true })
-
-            // 하나씩 복사
             await Promise.all(
                 entries.map(async (src) => {
                     const dest = path.join("build", src)


### PR DESCRIPTION
close #92
close #165

### 테스트명령어
```
pnpm run build && pnpm link --global  
itdoc generate
```

1. 이전 PR이 lint 통과되게 만들었으며 좀 더 깔끔하게 다듬었습니다.
참고PR : https://github.com/do-pa/itdoc/pull/166

2. itdoc cli의 모습을 처음에는 라이브러리를 써서 형광느낌이 나게 했는데 기존 logger를 써서 경량화했습니다.  
### before
![438088828-fc7b8a45-ebb6-4dc2-bb4d-1c8b0a586df6](https://github.com/user-attachments/assets/88715e4f-4e4f-4bab-9b30-ce832e6eeabd)

### after
![스크린샷 2025-04-29 오전 6 47 35](https://github.com/user-attachments/assets/7a5c667e-fc15-4606-91ea-83c52245c0d8)
