### PR TITLE
docs: modify Docusaurus config for itdoc homepage updates

### DIFF
--- a/itdoc-doc/docusaurus.config.ts
+++ b/itdoc-doc/docusaurus.config.ts
@@ -39,7 +39,7 @@ const config: Config = {
             {
                 docs: {
                     sidebarPath: "./sidebars.ts",
-                    editUrl: "https://github.com/do-pa/itdoc/",
+                    editUrl: "https://github.com/do-pa/itdoc/tree/main/itdoc-doc",
                 },
                 blog: {
                     showReadingTime: true,
@@ -47,7 +47,7 @@ const config: Config = {
                         type: ["rss", "atom"],
                         xslt: true,
                     },
-                    editUrl: "https://github.com/do-pa/itdoc/",
+                    editUrl: "https://github.com/do-pa/itdoc/tree/main/itdoc-doc",
                     onInlineTags: "warn",
                     onInlineAuthors: "warn",
                     onUntruncatedBlogPosts: "warn",

--- a/itdoc-doc/docusaurus.config.ts
+++ b/itdoc-doc/docusaurus.config.ts
@@ -3,7 +3,7 @@ import type { Config } from "@docusaurus/types"
 import type * as Preset from "@docusaurus/preset-classic"
 
 const config: Config = {
-    title: "itdoc",
+    title: "itdoc documentation",
     tagline: "Reliable API documentation, automatically generated from your tests",
     favicon: "img/favicon.ico",
     url: "https://itdoc.kr",

--- a/itdoc-doc/docusaurus.config.ts
+++ b/itdoc-doc/docusaurus.config.ts
@@ -24,6 +24,15 @@ const config: Config = {
             },
         },
     },
+    plugins: [
+        [
+            "@docusaurus/plugin-google-gtag",
+            {
+                trackingID: "G-VJW3NW4CYJ",
+                anonymizeIP: true,
+            },
+        ],
+    ],
     presets: [
         [
             "classic",

--- a/itdoc-doc/package.json
+++ b/itdoc-doc/package.json
@@ -21,6 +21,7 @@
     },
     "dependencies": {
         "@docusaurus/core": "3.7.0",
+        "@docusaurus/plugin-google-gtag": "^3.7.0",
         "@docusaurus/preset-classic": "3.7.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",

--- a/itdoc-doc/package.json
+++ b/itdoc-doc/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "my-website",
+    "name": "itdoc-doc",
     "version": "0.0.0",
     "private": true,
     "scripts": {

--- a/itdoc-doc/pnpm-lock.yaml
+++ b/itdoc-doc/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@docusaurus/core':
         specifier: 3.7.0
         version: 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@19.1.0))(acorn@8.14.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.6.3)
+      '@docusaurus/plugin-google-gtag':
+        specifier: ^3.7.0
+        version: 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@19.1.0))(acorn@8.14.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.6.3)
       '@docusaurus/preset-classic':
         specifier: 3.7.0
         version: 3.7.0(@algolia/client-search@5.23.2)(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(acorn@8.14.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(search-insights@2.17.3)(typescript@5.6.3)

--- a/itdoc-doc/pnpm-workspace.yaml
+++ b/itdoc-doc/pnpm-workspace.yaml
@@ -1,2 +1,2 @@
-packages: 
-    - "itdoc-doc" 
+packages:
+    - "itdoc-doc"

--- a/itdoc-doc/src/pages/index.tsx
+++ b/itdoc-doc/src/pages/index.tsx
@@ -34,7 +34,7 @@ export default function Home(): ReactNode {
     return (
         <Layout
             title={`${siteConfig.title}`}
-            description="Description will go into a meta tag in <head />"
+            description="Reliable API documentation automatically generated from your JavaScript/TypeScript"
         >
             <HomepageHeader />
             <main>

--- a/itdoc-doc/src/pages/index.tsx
+++ b/itdoc-doc/src/pages/index.tsx
@@ -21,7 +21,7 @@ function HomepageHeader() {
           <Link
             className="button button--secondary button--lg"
             to="/docs/intro">
-              Introduce itdoc 
+              Introduce itdoc
           </Link>
         </div>
       </div>
@@ -30,15 +30,16 @@ function HomepageHeader() {
 }
 
 export default function Home(): ReactNode {
-  const {siteConfig} = useDocusaurusContext();
-  return (
-    <Layout
-      title={`Hello from ${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />">
-      <HomepageHeader />
-      <main>
-        <HomepageFeatures />
-      </main>
-    </Layout>
-  );
+    const { siteConfig } = useDocusaurusContext()
+    return (
+        <Layout
+            title={`${siteConfig.title}`}
+            description="Description will go into a meta tag in <head />"
+        >
+            <HomepageHeader />
+            <main>
+                <HomepageFeatures />
+            </main>
+        </Layout>
+    )
 }

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
         "test": "pnpm build && pnpm test:unit && pnpm test:e2e",
         "test:unit": "mocha",
         "test:e2e": "pnpm --filter example-express test && pnpm --filter testframework-compatibility-test test && pnpm --filter example-nestjs test && pnpm --filter example-fastify test",
-        "docs": "cd itdoc-doc && pnpm install && pnpm run start",
-        "docs-build": "cd itdoc-doc && pnpm install && pnpm run build"
+        "docs": "pnpm --filter itdoc-doc run start",
+        "docs-build": "pnpm --filter itdoc-doc run build"
     },
     "lint-staged": {
         "*.{ts,mts}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,6 +331,9 @@ importers:
       '@docusaurus/core':
         specifier: 3.7.0
         version: 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@19.0.0))(@swc/core@1.11.29)(acorn@8.14.1)(esbuild@0.25.0)(eslint@9.17.0(jiti@1.21.7)(supports-color@10.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@10.0.0)(typescript@5.6.3)
+      '@docusaurus/plugin-google-gtag':
+        specifier: ^3.7.0
+        version: 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@19.0.0))(@swc/core@1.11.29)(acorn@8.14.1)(esbuild@0.25.0)(eslint@9.17.0(jiti@1.21.7)(supports-color@10.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@10.0.0)(typescript@5.6.3)
       '@docusaurus/preset-classic':
         specifier: 3.7.0
         version: 3.7.0(@algolia/client-search@5.23.3)(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@19.0.0))(@swc/core@1.11.29)(@types/react@19.1.0)(acorn@8.14.1)(esbuild@0.25.0)(eslint@9.17.0(jiti@1.21.7)(supports-color@10.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(supports-color@10.0.0)(typescript@5.6.3)


### PR DESCRIPTION
# Summary

Made configuration changes related to `itdoc-doc`.

# Changes

- Changed documentation title
  - <img width="683" alt="image" src="https://github.com/user-attachments/assets/fcb8ba98-ae53-40a7-b00b-99b41f8fb7bb" />
  - The default title was `Hello from Itdoc`, which has been updated to the more appropriate `Itdoc Documentation`.

- Integrated Google Analytics with itdoc
  - The connected account is the Gmail address previously shared. (https://analytics.google.com/)

- Updated the "Edit this page" link
  - <img width="649" alt="image" src="https://github.com/user-attachments/assets/22476ee6-c8d6-4464-b994-44607ca330dd" />
  - Fixed the previously broken hyperlink.
