### PR TITLE
fix: apply header key normalized to lowercase

### DIFF
--- a/lib/dsl/test-builders/RequestBuilder.ts
+++ b/lib/dsl/test-builders/RequestBuilder.ts
@@ -25,12 +25,18 @@ import { AbstractTestBuilder } from "./AbstractTestBuilder"
  */
 export class RequestBuilder extends AbstractTestBuilder {
     /**
-     * Sets headers to be used in requests.
+     * Sets headers to be used in requests. Header names are normalized to lowercase.
      * @param {Record<string, DSLField<string>>} headers Headers to be used in requests
      * @returns {this} Request builder instance
      */
     public header(headers: Record<string, DSLField<string>>): this {
-        this.config.requestHeaders = headers
+        const normalizedHeaders: Record<string, DSLField<string>> = {}
+
+        Object.entries(headers).forEach(([headerName, headerValue]) => {
+            normalizedHeaders[headerName.toLowerCase()] = headerValue
+        })
+
+        this.config.requestHeaders = normalizedHeaders
         return this
     }
 


### PR DESCRIPTION
# ko


표준에 따르면 header key는 대소문자 구분이 되면 안됩니다.
하지만 현재 itdoc에서는 아래와 같은 테스트가 작성되면 내부 동작이 달라질 수 있습니다.

```js
.req()
.header('content-type', ..)
```

```js
.req()
.header('CONTENT-TYpe', ..)
```

대소문자 정규화가 되지 않기 때문에, 아래와 같은 코드들이 동작되지 않을 수 있습니다.

<img width="668" height="466" alt="image" src="https://github.com/user-attachments/assets/93aa98f3-f219-48c5-a9c5-861e1a7541ee" />

이런 버그를 수정했습니다.


# en

According to the specification, header keys must not be case-sensitive.
However, in itdoc, if tests are written like the following, the internal behavior may differ:

```js
.req()
.header('content-type', ..)
```

```js
.req()
.header('CONTENT-TYpe', ..)
```


Because header keys are not normalized, certain code paths may not work as expected:

<img width="668" height="466" alt="image" src="https://github.com/user-attachments/assets/93aa98f3-f219-48c5-a9c5-861e1a7541ee" />



----

closed #250 