### PR TITLE
fix: resolve syntax error in generated openapi json

### DIFF
--- a/examples/express/expected/oas.json
+++ b/examples/express/expected/oas.json
@@ -89,7 +89,7 @@
                 }
             }
         },
-        "/users/:userId": {
+        "/users/{userId}": {
             "get": {
                 "summary": "사용자 조회 API",
                 "tags": ["User"],
@@ -383,7 +383,7 @@
                 }
             }
         },
-        "/users/:userId/friends/:friendName": {
+        "/users/{userId}/friends/{friendName}": {
             "delete": {
                 "summary": "특정 사용자의 친구를 삭제합니다.",
                 "tags": ["User"],

--- a/lib/__tests__/unit/dsl/OpenAPIGenerator.test.ts
+++ b/lib/__tests__/unit/dsl/OpenAPIGenerator.test.ts
@@ -231,4 +231,24 @@ describe("OpenAPIGenerator", () => {
             assert.isUndefined(spec.paths["/test/no-body-responses"].get.responses["400"].content)
         })
     })
+
+    describe("normalizePathTemplate", () => {
+        it("should convert Express-style params to OpenAPI format", () => {
+            const generator = OpenAPIGenerator.getInstance()
+            const normalized = generator["normalizePathTemplate"]("/users/:userId/posts/:postId")
+            assert.strictEqual(normalized, "/users/{userId}/posts/{postId}")
+        })
+
+        it("should handle already normalized paths", () => {
+            const generator = OpenAPIGenerator.getInstance()
+            const normalized = generator["normalizePathTemplate"]("/users/{userId}")
+            assert.strictEqual(normalized, "/users/{userId}")
+        })
+
+        it("should handle already normalized paths", () => {
+            const generator = OpenAPIGenerator.getInstance()
+            const normalized = generator["normalizePathTemplate"]("/files/:file-name")
+            assert.strictEqual(normalized, "/files/{file-name}")
+        })
+    })
 })

--- a/lib/__tests__/unit/dsl/OpenAPIGenerator.test.ts
+++ b/lib/__tests__/unit/dsl/OpenAPIGenerator.test.ts
@@ -233,19 +233,37 @@ describe("OpenAPIGenerator", () => {
     })
 
     describe("normalizePathTemplate", () => {
-        it("should convert Express-style params to OpenAPI format", () => {
+        it("should handle paths without parameters", () => {
             const generator = OpenAPIGenerator.getInstance()
-            const normalized = generator["normalizePathTemplate"]("/users/:userId/posts/:postId")
+            const normalized = generator["normalizePathTemplate"]("/users")
+            assert.strictEqual(normalized, "/users")
+        })
+
+        it("should handle mixed format paths", () => {
+            const generator = OpenAPIGenerator.getInstance()
+            const normalized = generator["normalizePathTemplate"]("/users/{userId}/posts/:postId")
             assert.strictEqual(normalized, "/users/{userId}/posts/{postId}")
         })
 
-        it("should handle already normalized paths", () => {
+        it("should handle parameters with underscores", () => {
             const generator = OpenAPIGenerator.getInstance()
-            const normalized = generator["normalizePathTemplate"]("/users/{userId}")
-            assert.strictEqual(normalized, "/users/{userId}")
+            const normalized = generator["normalizePathTemplate"]("/items/:item_id")
+            assert.strictEqual(normalized, "/items/{item_id}")
         })
 
-        it("should handle already normalized paths", () => {
+        it("should handle empty path", () => {
+            const generator = OpenAPIGenerator.getInstance()
+            const normalized = generator["normalizePathTemplate"]("")
+            assert.strictEqual(normalized, "")
+        })
+
+        it("should handle root path", () => {
+            const generator = OpenAPIGenerator.getInstance()
+            const normalized = generator["normalizePathTemplate"]("/")
+            assert.strictEqual(normalized, "/")
+        })
+
+        it("should handle hyphenated parameter names", () => {
             const generator = OpenAPIGenerator.getInstance()
             const normalized = generator["normalizePathTemplate"]("/files/:file-name")
             assert.strictEqual(normalized, "/files/{file-name}")

--- a/lib/dsl/generator/OpenAPIGenerator.ts
+++ b/lib/dsl/generator/OpenAPIGenerator.ts
@@ -581,7 +581,7 @@ export class OpenAPIGenerator implements IOpenAPIGenerator {
      * @returns {string} Normalized OpenAPI path
      */
     private normalizePathTemplate(path: string): string {
-        return path.replace(/:([A-Za-z0-9_]+)/g, "{$1}")
+        return path.replace(/:([A-Za-z0-9_-]+)/g, "{$1}")
     }
 
     /**

--- a/lib/dsl/test-builders/RequestBuilder.ts
+++ b/lib/dsl/test-builders/RequestBuilder.ts
@@ -19,6 +19,7 @@ import { DSLField } from "../interface"
 import { ResponseBuilder } from "./ResponseBuilder"
 import { FIELD_TYPES } from "../interface/field"
 import { AbstractTestBuilder } from "./AbstractTestBuilder"
+import logger from "../../config/logger"
 
 /**
  * Builder class for setting API request information.
@@ -31,9 +32,18 @@ export class RequestBuilder extends AbstractTestBuilder {
      */
     public header(headers: Record<string, DSLField<string>>): this {
         const normalizedHeaders: Record<string, DSLField<string>> = {}
+        const seen = new Set<string>()
 
         Object.entries(headers).forEach(([headerName, headerValue]) => {
-            normalizedHeaders[headerName.toLowerCase()] = headerValue
+            const normalized = headerName.toLowerCase()
+
+            if (seen.has(normalized)) {
+                logger.warn(`Duplicate header detected: "${headerName}" (already set)`)
+                return
+            }
+
+            seen.add(normalized)
+            normalizedHeaders[normalized] = headerValue
         })
 
         this.config.requestHeaders = normalizedHeaders


### PR DESCRIPTION
# ko

생성된 oas.json에 syntax 에러가 발생해서 이를 해결합니다.

# en

A syntax error occurred in the generated oas.json, and this commit resolves it.

# result 

## AS-IS

> syntax error was displayed

<img width="1211" height="541" alt="image" src="https://github.com/user-attachments/assets/19187c77-ac83-4a9b-8251-bc4ded2b0f78" />

## TO-BE

> syntax error was not displaying

<img width="1228" height="662" alt="image" src="https://github.com/user-attachments/assets/35a9c513-c9ed-49f7-a198-1226c036adb7" />


----

closed #252 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAPI paths now use standard {param} syntax instead of :param, improving spec compliance and tooling compatibility.
  * Path parameter handling normalized to prevent mismatches between declared paths and parameters.
  * Request builder now detects and skips duplicate headers (case-insensitive) and emits a warning.

* **Documentation**
  * Updated generated OpenAPI example to reflect corrected path templates.

* **Tests**
  * Added unit tests verifying path template normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->